### PR TITLE
Introduced Labeling system

### DIFF
--- a/src/AppBundle/Issues/Listener.php
+++ b/src/AppBundle/Issues/Listener.php
@@ -6,8 +6,6 @@ class Listener
 {
     private static $triggerWordToStatus = [
         'needs review' => Status::NEEDS_REVIEW,
-        'needs work' => Status::NEEDS_WORK,
-        'works for me' => Status::WORKS_FOR_ME,
         'reviewed' => Status::REVIEWED,
         'qa approved' => Status::QA_APPROVED,
         'pm approved' => Status::PM_APPROVED,

--- a/src/AppBundle/Issues/Status.php
+++ b/src/AppBundle/Issues/Status.php
@@ -11,10 +11,6 @@ final class Status
 {
     const NEEDS_REVIEW = 'needs_review';
 
-    const NEEDS_WORK = 'needs_work';
-
-    const WORKS_FOR_ME = 'works_for_me';
-
     const REVIEWED = 'reviewed';
 
     const QA_APPROVED = 'qa_approved';

--- a/src/AppBundle/Issues/StatusApi.php
+++ b/src/AppBundle/Issues/StatusApi.php
@@ -8,8 +8,6 @@ class StatusApi
 {
     private $statusToLabel = [
         Status::NEEDS_REVIEW => 'Status: Needs Review',
-        Status::NEEDS_WORK => 'Status: Needs Work',
-        Status::WORKS_FOR_ME => 'Status: Works for me',
         Status::REVIEWED => 'Status: Reviewed',
         Status::QA_APPROVED => 'QA-approved',
         Status::PM_APPROVED => 'PM-approved',

--- a/tests/AppBundle/Issues/IssueListenerTest.php
+++ b/tests/AppBundle/Issues/IssueListenerTest.php
@@ -64,10 +64,6 @@ class IssueListenerTest extends \PHPUnit_Framework_TestCase
             Status::NEEDS_REVIEW,
         ];
         $tests[] = [
-            'Status: needs work',
-            Status::NEEDS_WORK,
-        ];
-        $tests[] = [
             'Status: reviewed',
             Status::REVIEWED,
         ];
@@ -81,17 +77,6 @@ class IssueListenerTest extends \PHPUnit_Framework_TestCase
             "Status: 'reviewed'",
             Status::REVIEWED,
         ];
-
-        // accept trailing punctuation
-        $tests[] = [
-            'Status: works for me!',
-            Status::WORKS_FOR_ME,
-        ];
-        $tests[] = [
-            'Status: works for me.',
-            Status::WORKS_FOR_ME,
-        ];
-
         // play with different formatting
         $tests[] = [
             'STATUS: REVIEWED',
@@ -219,7 +204,7 @@ class IssueListenerTest extends \PHPUnit_Framework_TestCase
         $this->statusApi->expects($this->once())
             ->method('getIssueStatus')
             ->with(1234)
-            ->willReturn(Status::NEEDS_WORK);
+            ->willReturn(Status::NEEDS_REVIEW);
 
         $this->statusApi->expects($this->never())
             ->method('setIssueStatus');

--- a/tests/AppBundle/Issues/StatusApiTest.php
+++ b/tests/AppBundle/Issues/StatusApiTest.php
@@ -73,7 +73,7 @@ class StatusApiTest extends \PHPUnit_Framework_TestCase
         $this->labelsApi->expects($this->at(0))
             ->method('getIssueLabels')
             ->with(1234)
-            ->willReturn(['Bug', 'Status: Needs Review', 'Status: Needs Work']);
+            ->willReturn(['Bug', 'Status: Needs Review', 'QA-approved']);
 
         $this->labelsApi->expects($this->at(1))
             ->method('removeIssueLabel')
@@ -81,7 +81,7 @@ class StatusApiTest extends \PHPUnit_Framework_TestCase
 
         $this->labelsApi->expects($this->at(2))
             ->method('removeIssueLabel')
-            ->with(1234, 'Status: Needs Work');
+            ->with(1234, 'QA-approved');
 
         $this->labelsApi->expects($this->at(3))
             ->method('addIssueLabel')


### PR DESCRIPTION
Hi,

if someone comment a pull request, saying `Status: 'PM approved'` or `Status: 'QA approved'`, the related label will be added.

Todo:
- [x] Remove previous labels from old carsonbot fork

Regards,
