### PR TITLE
Removed prestonBot validation comment if become valid

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -72,7 +72,7 @@ services:
     app.issue_listener:
         class: AppBundle\Issues\Listener
         arguments: ['@app.status_api']
-    
+
     app.pullrequest_listener:
         class: AppBundle\PullRequests\Listener
         arguments: ['@app.comment_api', '@validator']

--- a/composer.lock
+++ b/composer.lock
@@ -2459,16 +2459,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9"
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/900370c81280cc0d942ffbc5912d80464eaee7e9",
-                "reference": "900370c81280cc0d942ffbc5912d80464eaee7e9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
                 "shasum": ""
             },
             "require": {
@@ -2477,7 +2477,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "^1.4.2",
                 "sebastian/code-unit-reverse-lookup": "~1.0",
-                "sebastian/environment": "^1.3.2",
+                "sebastian/environment": "^1.3.2 || ^2.0",
                 "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
@@ -2518,7 +2518,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-06-03 05:03:56"
+            "time": "2016-07-26 14:39:29"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2703,16 +2703,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.4.7",
+            "version": "5.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6c8a756c17a1a92a066c99860eb57922e8b723da"
+                "reference": "3132365e1430c091f208e120b8845d39c25f20e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6c8a756c17a1a92a066c99860eb57922e8b723da",
-                "reference": "6c8a756c17a1a92a066c99860eb57922e8b723da",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3132365e1430c091f208e120b8845d39c25f20e6",
+                "reference": "3132365e1430c091f208e120b8845d39c25f20e6",
                 "shasum": ""
             },
             "require": {
@@ -2724,7 +2724,7 @@
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/php-code-coverage": "^4.0.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
@@ -2777,7 +2777,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:55:27"
+            "time": "2016-07-26 14:48:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/src/AppBundle/PullRequests/Listener.php
+++ b/src/AppBundle/PullRequests/Listener.php
@@ -4,29 +4,50 @@ namespace AppBundle\PullRequests;
 
 use AppBundle\Comments\CommentApi;
 use Lpdigital\Github\Entity\PullRequest;
+use AppBundle\PullRequests\Repository as PullRequestRepository;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-/**
- * Note to myself: too much logic in this Listener.
- */
 class Listener
 {
     private $commentApi;
     private $validator;
+    private $repository;
 
-    public function __construct(CommentApi $commentApi, ValidatorInterface $validator)
-    {
+    const PRESTONBOT_NAME = 'prestonBot';
+
+    public function __construct(
+        CommentApi $commentApi,
+        ValidatorInterface $validator,
+        PullRequestRepository $repository
+    ) {
         $this->commentApi = $commentApi;
         $this->validator = $validator;
+        $this->repository = $repository;
     }
 
-    public function checkForDescription(PullRequest $pullRequest, $commitId)
+    public function handlePullRequestCreatedEvent(PullRequest $pullRequest, $commitId)
     {
         $bodyParser = new BodyParser($pullRequest->getBody());
 
         $validationErrors = $this->validator->validate($bodyParser);
         if (count($validationErrors) > 0) {
-            $this->commentApi->sendWithTemplate($pullRequest, 'markdown/pr_table_errors.md.twig', ['errors' => $validationErrors]);
+            $this->commentApi->sendWithTemplate(
+                $pullRequest,
+                'markdown/pr_table_errors.md.twig',
+                ['errors' => $validationErrors]
+            );
+        }
+    }
+
+    public function handlePullRequestEditedEvent(PullRequest $pullRequest)
+    {
+        $prestonComments = $this->repository
+            ->getCommentsFrom($pullRequest, self::PRESTONBOT_NAME)
+        ;
+
+        if (count($prestonComments) > 0) {
+            $validationComment = $prestonComments[0];
+            $this->commentApi->remove($pullRequest, $validationComment->getId());
         }
     }
 }

--- a/src/AppBundle/PullRequests/Repository.php
+++ b/src/AppBundle/PullRequests/Repository.php
@@ -87,6 +87,28 @@ class Repository
         return $comments;
     }
 
+    /**
+     * Return Comments of selected user if any.
+     * 
+     * @param PullRequest Lpdigital\Github\Entity\PullRequest
+     * @param string login from Entity User of Comment entry
+     * 
+     * @return array collection of user's comments
+     */
+    public function getCommentsFrom(PullRequest $pullRequest, $userLogin)
+    {
+        $comments = $this->getComments($pullRequest);
+        $userComments = [];
+
+        foreach ($comments as $comment) {
+            if ($userLogin === $comment->getUserLogin()) {
+                $userComments[] = $comment;
+            }
+        }
+
+        return $comments;
+    }
+
     private function parseLabel($label)
     {
         return '"'.$label.'"';

--- a/tests/AppBundle/PullRequests/FakeListener.php
+++ b/tests/AppBundle/PullRequests/FakeListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig_Environment;
 
 /**
- * Note to myself: in integrations tests, don't send comments!
+ * We don't create/update/delete comments intentionally.
  */
 class FakeListener
 {
@@ -24,7 +24,7 @@ class FakeListener
         $this->twig = $twig;
     }
 
-    public function checkForDescription(PullRequest $pullRequest, $commitId)
+    public function handlePullRequestCreatedEvent(PullRequest $pullRequest, $commitId)
     {
         $bodyParser = new BodyParser($pullRequest->getBody());
 
@@ -34,5 +34,20 @@ class FakeListener
 
             return true;
         }
+    }
+
+    public function handlePullRequestEditedEvent(PullRequest $pullRequest)
+    {
+        $prestonComments = $this->repository
+            ->getCommentsFrom($pullRequest, self::PRESTONBOT_NAME)
+        ;
+
+        if (count($prestonComments) > 0) {
+            $validationComment = $prestonComments[0];
+            
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Last step of https://github.com/mickaelandrieu/prestonbot/issues/7 : now we can get the pull request comments et be able to remove a comment by his identifier, we can remove the validation message when the description have been updated and is valid !
